### PR TITLE
Encoder + Speedcontroller = ❤️

### DIFF
--- a/src/main/java/com/chopshop166/chopshoplib/outputs/EncodedSpeedController.java
+++ b/src/main/java/com/chopshop166/chopshoplib/outputs/EncodedSpeedController.java
@@ -13,11 +13,28 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
  */
 public interface EncodedSpeedController extends SendableSpeedController, EncoderInterface {
 
-    static EncodedSpeedController wrap(CANSparkMax spark) {
+    /**
+     * Create an {@link EncodedSpeedController} out of a {@link CANSparkMax}.
+     * 
+     * The Spark Max has a built in encoder. For ease of use, this relies on the
+     * existing {@link #join(SendableSpeedController, EncoderInterface)} to create a
+     * wrapped object.
+     * 
+     * @param spark A Spark Max object with an associated encoder.
+     * @return A wrapped object.
+     */
+    static EncodedSpeedController wrap(final CANSparkMax spark) {
         return join(new SparkMaxSendable(spark), new SparkMaxEncoder(spark.getEncoder()));
     }
 
-    static EncodedSpeedController join(SendableSpeedController sc, EncoderInterface enc) {
+    /**
+     * Combine a speed controller and an encoder into a single object.
+     * 
+     * @param sc  The speed controller.
+     * @param enc The encoder.
+     * @return A wrapped object.
+     */
+    static EncodedSpeedController join(final SendableSpeedController sc, final EncoderInterface enc) {
         return new EncodedSpeedController() {
 
             @Override

--- a/src/main/java/com/chopshop166/chopshoplib/outputs/EncodedSpeedController.java
+++ b/src/main/java/com/chopshop166/chopshoplib/outputs/EncodedSpeedController.java
@@ -1,0 +1,117 @@
+package com.chopshop166.chopshoplib.outputs;
+
+import com.chopshop166.chopshoplib.sensors.EncoderInterface;
+import com.chopshop166.chopshoplib.sensors.SparkMaxEncoder;
+import com.revrobotics.CANSparkMax;
+
+import edu.wpi.first.wpilibj.PIDSourceType;
+import edu.wpi.first.wpilibj.SpeedController;
+import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+
+/**
+ * {@link SpeedController} that also acts as an {@link EncoderInterface}.
+ */
+public interface EncodedSpeedController extends SendableSpeedController, EncoderInterface {
+
+    static EncodedSpeedController wrap(CANSparkMax spark) {
+        return join(new SparkMaxSendable(spark), new SparkMaxEncoder(spark.getEncoder()));
+    }
+
+    static EncodedSpeedController join(SendableSpeedController sc, EncoderInterface enc) {
+        return new EncodedSpeedController() {
+
+            @Override
+            public String getName() {
+                return sc.getName();
+            }
+
+            @Override
+            public void setName(String name) {
+                sc.setName(name);
+            }
+
+            @Override
+            public String getSubsystem() {
+                return sc.getSubsystem();
+            }
+
+            @Override
+            public void setSubsystem(String subsystem) {
+                sc.setSubsystem(subsystem);
+            }
+
+            @Override
+            public void initSendable(SendableBuilder builder) {
+                enc.initSendable(builder);
+                sc.initSendable(builder);
+            }
+
+            @Override
+            public void set(double speed) {
+                sc.set(speed);
+            }
+
+            @Override
+            public double get() {
+                return sc.get();
+            }
+
+            @Override
+            public void setInverted(boolean isInverted) {
+                sc.setInverted(isInverted);
+            }
+
+            @Override
+            public boolean getInverted() {
+                return sc.getInverted();
+            }
+
+            @Override
+            public void disable() {
+                sc.disable();
+            }
+
+            @Override
+            public void stopMotor() {
+                sc.stopMotor();
+            }
+
+            @Override
+            public void pidWrite(double output) {
+                sc.pidWrite(output);
+            }
+
+            @Override
+            public void reset() {
+                enc.reset();
+            }
+
+            @Override
+            public double getDistance() {
+                return enc.getDistance();
+            }
+
+            @Override
+            public double getRate() {
+                return enc.getRate();
+            }
+
+            @Override
+            public void setPIDSourceType(PIDSourceType pidSource) {
+                enc.setPIDSourceType(pidSource);
+            }
+
+            @Override
+            public PIDSourceType getPIDSourceType() {
+                return enc.getPIDSourceType();
+            }
+
+            @Override
+            public double pidGet() {
+                return enc.pidGet();
+            }
+
+        };
+    }
+
+}

--- a/src/main/java/com/chopshop166/chopshoplib/sensors/EncoderInterface.java
+++ b/src/main/java/com/chopshop166/chopshoplib/sensors/EncoderInterface.java
@@ -1,10 +1,7 @@
 package com.chopshop166.chopshoplib.sensors;
 
-import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.PIDSource;
-import edu.wpi.first.wpilibj.PIDSourceType;
 import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 
 /**
  * Interface for an Encoder
@@ -50,72 +47,4 @@ public interface EncoderInterface extends PIDSource, Sendable {
         return getRate() > 0;
     }
 
-    static EncoderInterface wrap(final Encoder encoder) {
-        return new EncoderInterface() {
-            @Override
-            public void setPIDSourceType(PIDSourceType pidSource) {
-                encoder.setPIDSourceType(pidSource);
-            }
-
-            @Override
-            public PIDSourceType getPIDSourceType() {
-                return encoder.getPIDSourceType();
-            }
-
-            @Override
-            public double pidGet() {
-                return encoder.pidGet();
-            }
-
-            @Override
-            public String getName() {
-                return encoder.getName();
-            }
-
-            @Override
-            public void setName(String name) {
-                encoder.setName(name);
-            }
-
-            @Override
-            public String getSubsystem() {
-                return encoder.getSubsystem();
-            }
-
-            @Override
-            public void setSubsystem(String subsystem) {
-                encoder.setSubsystem(subsystem);
-            }
-
-            @Override
-            public void initSendable(SendableBuilder builder) {
-                encoder.initSendable(builder);
-            }
-
-            @Override
-            public void reset() {
-                encoder.reset();
-            }
-
-            @Override
-            public double getDistance() {
-                return encoder.getDistance();
-            }
-
-            @Override
-            public double getRate() {
-                return encoder.getRate();
-            }
-
-            @Override
-            public boolean isStopped() {
-                return encoder.getStopped();
-            }
-
-            @Override
-            public boolean isMovingForward() {
-                return encoder.getDirection();
-            }
-        };
-    }
 }

--- a/src/main/java/com/chopshop166/chopshoplib/sensors/WrappedEncoder.java
+++ b/src/main/java/com/chopshop166/chopshoplib/sensors/WrappedEncoder.java
@@ -3,6 +3,11 @@ package com.chopshop166.chopshoplib.sensors;
 import edu.wpi.first.wpilibj.DigitalSource;
 import edu.wpi.first.wpilibj.Encoder;
 
+/**
+ * An instance of {@link Encoder} that adheres to {@link EncoderInterface}.
+ * 
+ * The constructor arguments are the same as the ones in the base class.
+ */
 public class WrappedEncoder extends Encoder implements EncoderInterface {
 
     public WrappedEncoder(final int channelA, final int channelB, final boolean reverseDirection) {

--- a/src/main/java/com/chopshop166/chopshoplib/sensors/WrappedEncoder.java
+++ b/src/main/java/com/chopshop166/chopshoplib/sensors/WrappedEncoder.java
@@ -1,0 +1,56 @@
+package com.chopshop166.chopshoplib.sensors;
+
+import edu.wpi.first.wpilibj.DigitalSource;
+import edu.wpi.first.wpilibj.Encoder;
+
+public class WrappedEncoder extends Encoder implements EncoderInterface {
+
+    public WrappedEncoder(final int channelA, final int channelB, final boolean reverseDirection) {
+        super(channelA, channelB, reverseDirection);
+    }
+
+    public WrappedEncoder(final int channelA, final int channelB) {
+        super(channelA, channelB, false);
+    }
+
+    public WrappedEncoder(final int channelA, final int channelB, final boolean reverseDirection,
+            final EncodingType encodingType) {
+        super(channelA, channelB, reverseDirection, encodingType);
+    }
+
+    public WrappedEncoder(final int channelA, final int channelB, final int indexChannel,
+            final boolean reverseDirection) {
+        super(channelA, channelB, indexChannel, reverseDirection);
+    }
+
+    public WrappedEncoder(final int channelA, final int channelB, final int indexChannel) {
+        super(channelA, channelB, indexChannel);
+    }
+
+    public WrappedEncoder(final DigitalSource sourceA, final DigitalSource sourceB, final boolean reverseDirection) {
+        super(sourceA, sourceB, reverseDirection);
+    }
+
+    public WrappedEncoder(final DigitalSource sourceA, final DigitalSource sourceB) {
+        super(sourceA, sourceB);
+    }
+
+    public WrappedEncoder(final DigitalSource sourceA, final DigitalSource sourceB, final boolean reverseDirection,
+            final EncodingType encodingType) {
+        super(sourceA, sourceB, reverseDirection, encodingType);
+    }
+
+    public WrappedEncoder(final DigitalSource sourceA, final DigitalSource sourceB, final DigitalSource indexSource,
+            final boolean reverseDirection) {
+        super(sourceA, sourceB, indexSource, reverseDirection);
+    }
+
+    public WrappedEncoder(final DigitalSource sourceA, final DigitalSource sourceB, final DigitalSource indexSource) {
+        super(sourceA, sourceB, indexSource);
+    }
+
+    @Override
+    public boolean isMovingForward() {
+        return getDirection();
+    }
+}


### PR DESCRIPTION
Create an interface that acts as both an Encoder and a Speed Controller.

This is useful because it allows us to carry around both pieces of information in one variable. It may be helpful for future work with Pathfinder, for instance.

The current implementation has a `.join()` to combine two objects, and a `.wrap()` to wrap the SparkMAX, which already has an encoder in its native object.