### PR TITLE
Use `XBoxController.Button` instead of reimplementation

### DIFF
--- a/src/main/java/com/chopshop166/chopshoplib/controls/ButtonXboxController.java
+++ b/src/main/java/com/chopshop166/chopshoplib/controls/ButtonXboxController.java
@@ -1,6 +1,6 @@
 package com.chopshop166.chopshoplib.controls;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import edu.wpi.first.wpilibj.XboxController;
@@ -10,7 +10,7 @@ import edu.wpi.first.wpilibj2.command.button.JoystickButton;
  * Represents an XBox controller along with its associated buttons.
  */
 public class ButtonXboxController extends XboxController {
-    private final Map<Integer, JoystickButton> buttons = new HashMap<>();
+    private final Map<Button, JoystickButton> buttons = new EnumMap<>(Button.class);
 
     /**
      * Construct an instance of a joystick along with each button the joystick has.
@@ -31,48 +31,17 @@ public class ButtonXboxController extends XboxController {
      * @param buttonId The index of the button to accesss
      * @return The button object for the given ID
      */
-    public JoystickButton getButton(final int buttonId) {
+    public JoystickButton getButton(final Button buttonId) {
         if (!buttons.containsKey(buttonId)) {
-            buttons.put(buttonId, new JoystickButton(this, buttonId));
+            buttons.put(buttonId, new JoystickButton(this, buttonId.value));
         }
         return buttons.get(buttonId);
     }
 
     public double getTriggers() {
-
         final double kRight = getTriggerAxis(Hand.kRight);
         final double kLeft = getTriggerAxis(Hand.kLeft);
         return kRight - kLeft;
-    }
-
-    /**
-     * Get a button from this joystick
-     * <p>
-     * Returns the sepcified button of a joystick without having to explicitly
-     * create each button.
-     * 
-     * @param buttonId The index of the button to accesss
-     * @return The button object for the given ID
-     */
-    public JoystickButton getButton(final XBoxButton buttonId) {
-        return getButton(buttonId.get());
-    }
-
-    /**
-     * Public implementation of the enum from {@link XboxController}
-     */
-    public enum XBoxButton {
-        BUMPER_LEFT(5), BUMPER_RIGHT(6), STICK_LEFT(9), STICK_RIGHT(10), A(1), B(2), X(3), Y(4), BACK(7), START(8);
-
-        private final int value;
-
-        XBoxButton(final int value) {
-            this.value = value;
-        }
-
-        public int get() {
-            return value;
-        }
     }
 
 }

--- a/src/main/java/com/chopshop166/chopshoplib/triggers/AndTrigger.java
+++ b/src/main/java/com/chopshop166/chopshoplib/triggers/AndTrigger.java
@@ -7,6 +7,7 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 /**
  * A {@link Trigger} that triggers if every trigger passed to it is triggered.
  */
+@Deprecated(since = "2020", forRemoval = true)
 public class AndTrigger extends Trigger {
 
     private final Trigger[] triggers;

--- a/src/main/java/com/chopshop166/chopshoplib/triggers/BooleanTrigger.java
+++ b/src/main/java/com/chopshop166/chopshoplib/triggers/BooleanTrigger.java
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 /**
  * A trigger that responds to a function reference ({@link BooleanSupplier}).
  */
+@Deprecated(since = "2020", forRemoval = true)
 public class BooleanTrigger extends Trigger {
     private final BooleanSupplier supplier;
 

--- a/src/main/java/com/chopshop166/chopshoplib/triggers/OrTrigger.java
+++ b/src/main/java/com/chopshop166/chopshoplib/triggers/OrTrigger.java
@@ -7,6 +7,7 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 /**
  * A {@link Trigger} that triggers if any trigger passed to it is triggered.
  */
+@Deprecated(since = "2020", forRemoval = true)
 public class OrTrigger extends Trigger {
 
     private final Trigger[] triggers;

--- a/src/main/java/com/chopshop166/chopshoplib/triggers/XboxTrigger.java
+++ b/src/main/java/com/chopshop166/chopshoplib/triggers/XboxTrigger.java
@@ -2,13 +2,14 @@ package com.chopshop166.chopshoplib.triggers;
 
 import java.util.function.Function;
 
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 import edu.wpi.first.wpilibj.GenericHID.Hand;
 import edu.wpi.first.wpilibj.XboxController;
 
 /**
  * A trigger that responds to the trigger of an Xbox controller.
  */
-public class XboxTrigger extends BooleanTrigger {
+public class XboxTrigger extends Trigger {
 
     private final XboxController controller;
 


### PR DESCRIPTION
2020 made the enum public, so we don't need to duplicate it in our code.