### PR TITLE
Add Preset Subsystem and Smart Subsystem Base

### DIFF
--- a/config/pmd-ruleset.xml
+++ b/config/pmd-ruleset.xml
@@ -25,6 +25,7 @@
         <exclude name="VariableNamingConventions"/>
     </rule>
     <rule ref="category/java/design.xml">
+        <exclude name="AbstractClassWithoutAnyMethod"/>
         <exclude name="DataClass"/>
         <exclude name="LawOfDemeter"/>
         <exclude name="LoosePackageCoupling"/>

--- a/src/main/java/com/chopshop166/chopshoplib/commands/PresetSubsystem.java
+++ b/src/main/java/com/chopshop166/chopshoplib/commands/PresetSubsystem.java
@@ -2,6 +2,7 @@ package com.chopshop166.chopshoplib.commands;
 
 import java.util.function.DoubleSupplier;
 
+import com.chopshop166.chopshoplib.PersistenceCheck;
 import com.chopshop166.chopshoplib.Resettable;
 
 import edu.wpi.first.wpilibj.controller.PIDController;
@@ -9,6 +10,7 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.PIDSubsystem;
 import edu.wpi.first.wpilibj2.command.Subsystem;
+import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
 
 /**
  * A {@link Subsystem} that is {@link Resettable} and that provides convenience
@@ -17,13 +19,18 @@ import edu.wpi.first.wpilibj2.command.Subsystem;
 public abstract class PresetSubsystem<T extends Enum<?> & DoubleSupplier> extends PIDSubsystem
         implements SmartSubsystem {
 
+    /** Check to make sure it's at the setpoint for enough time */
+    private final PersistenceCheck persistenceCheck;
+
     /**
      * Construct the subsystem.
      * 
      * @param controller The PID controller to use.
+     * @param numSamples Number of setpoint valid samples to check for.
      */
-    public PresetSubsystem(final PIDController controller) {
+    public PresetSubsystem(final PIDController controller, final int numSamples) {
         super(controller);
+        persistenceCheck = new PersistenceCheck(numSamples, controller::atSetpoint);
     }
 
     /**
@@ -31,9 +38,11 @@ public abstract class PresetSubsystem<T extends Enum<?> & DoubleSupplier> extend
      * 
      * @param controller The PID controller to use.
      * @param initial    The initial value.
+     * @param numSamples Number of setpoint valid samples to check for.
      */
-    public PresetSubsystem(final PIDController controller, final double initial) {
+    public PresetSubsystem(final PIDController controller, final int numSamples, final double initial) {
         super(controller, initial);
+        persistenceCheck = new PersistenceCheck(numSamples, controller::atSetpoint);
     }
 
     /**
@@ -46,6 +55,27 @@ public abstract class PresetSubsystem<T extends Enum<?> & DoubleSupplier> extend
         return new InstantCommand(() -> {
             setSetpoint(value.getAsDouble());
         }, this).withName("Set to " + value.name());
+    }
+
+    /**
+     * Wait until the subsystem is moved to the proper setpoint.
+     * 
+     * @return The wait command.
+     */
+    public CommandBase waitForSetpoint() {
+        final CommandBase ret = new WaitUntilCommand(persistenceCheck).withName("Wait For Setpoint");
+        ret.addRequirements(this);
+        return ret;
+    }
+
+    /**
+     * Set the preset for the subsystem, and wait until it moves to that point.
+     * 
+     * @param value The preset to use.
+     * @return The instant command.
+     */
+    public CommandBase presetWait(final T value) {
+        return CommandRobot.sequence("Set to " + value.name(), presetCmd(value), waitForSetpoint());
     }
 
     @Override

--- a/src/main/java/com/chopshop166/chopshoplib/commands/PresetSubsystem.java
+++ b/src/main/java/com/chopshop166/chopshoplib/commands/PresetSubsystem.java
@@ -1,0 +1,56 @@
+package com.chopshop166.chopshoplib.commands;
+
+import java.util.function.DoubleSupplier;
+
+import com.chopshop166.chopshoplib.Resettable;
+
+import edu.wpi.first.wpilibj.controller.PIDController;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.PIDSubsystem;
+import edu.wpi.first.wpilibj2.command.Subsystem;
+
+/**
+ * A {@link Subsystem} that is {@link Resettable} and that provides convenience
+ * functions for common commands.
+ */
+public abstract class PresetSubsystem<T extends Enum<?> & DoubleSupplier> extends PIDSubsystem
+        implements SmartSubsystem {
+
+    /**
+     * Construct the subsystem.
+     * 
+     * @param controller The PID controller to use.
+     */
+    public PresetSubsystem(final PIDController controller) {
+        super(controller);
+    }
+
+    /**
+     * Construct the subsystem.
+     * 
+     * @param controller The PID controller to use.
+     * @param initial    The initial value.
+     */
+    public PresetSubsystem(final PIDController controller, final double initial) {
+        super(controller, initial);
+    }
+
+    /**
+     * Set the preset for the subsystem.
+     * 
+     * @param value The preset to use.
+     * @return The instant command.
+     */
+    public CommandBase presetCmd(final T value) {
+        return new InstantCommand(() -> {
+            setSetpoint(value.getAsDouble());
+        }, this).withName("Set to " + value.name());
+    }
+
+    @Override
+    public void reset() {
+        setSetpoint(getMeasurement());
+    }
+
+}

--- a/src/main/java/com/chopshop166/chopshoplib/commands/SmartSubsystem.java
+++ b/src/main/java/com/chopshop166/chopshoplib/commands/SmartSubsystem.java
@@ -7,20 +7,23 @@ import java.util.function.Consumer;
 
 import com.chopshop166.chopshoplib.Resettable;
 
+import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.StartEndCommand;
 import edu.wpi.first.wpilibj2.command.Subsystem;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
 
 /**
  * A {@link Subsystem} that is {@link Resettable} and that provides convenience
  * functions for common commands.
+ * 
+ * @see SmartSubsystemBase For class that provides wpilib-style defaults.
  */
-public abstract class SmartSubsystem extends SubsystemBase implements Resettable {
+public interface SmartSubsystem extends Subsystem, Resettable, Sendable {
 
     /**
      * Create a command builder with a given name.
@@ -28,7 +31,7 @@ public abstract class SmartSubsystem extends SubsystemBase implements Resettable
      * @param name The command name.
      * @return A new command builder.
      */
-    public CommandBuilder cmd(final String name) {
+    default CommandBuilder cmd(final String name) {
         return new CommandBuilder(name, this);
     }
 
@@ -44,7 +47,7 @@ public abstract class SmartSubsystem extends SubsystemBase implements Resettable
      * @param isFinished The condition to end the command.
      * @return A new command.
      */
-    public CommandBase functional(final String name, final Runnable onInit, final Runnable onExecute,
+    default CommandBase functional(final String name, final Runnable onInit, final Runnable onExecute,
             final Consumer<Boolean> onEnd, final BooleanSupplier isFinished) {
         final Runnable realOnInit = getValueOrDefault(onInit, () -> {
         });
@@ -63,7 +66,7 @@ public abstract class SmartSubsystem extends SubsystemBase implements Resettable
      * @param action The action to take.
      * @return A new command.
      */
-    public CommandBase instant(final String name, final Runnable action) {
+    default CommandBase instant(final String name, final Runnable action) {
         return new InstantCommand(action, this).withName(name);
     }
 
@@ -74,7 +77,7 @@ public abstract class SmartSubsystem extends SubsystemBase implements Resettable
      * @param action The action to take.
      * @return A new command.
      */
-    public CommandBase running(final String name, final Runnable action) {
+    default CommandBase running(final String name, final Runnable action) {
         return new RunCommand(action, this).withName(name);
     }
 
@@ -86,7 +89,7 @@ public abstract class SmartSubsystem extends SubsystemBase implements Resettable
      * @param onEnd   The action to take on end.
      * @return A new command.
      */
-    public CommandBase startEnd(final String name, final Runnable onStart, final Runnable onEnd) {
+    default CommandBase startEnd(final String name, final Runnable onStart, final Runnable onEnd) {
         return new StartEndCommand(onStart, onEnd, this).withName(name);
     }
 
@@ -98,7 +101,7 @@ public abstract class SmartSubsystem extends SubsystemBase implements Resettable
      * @param until The condition to wait until.
      * @return A new command.
      */
-    public CommandBase initAndWait(final String name, final Runnable init, final BooleanSupplier until) {
+    default CommandBase initAndWait(final String name, final Runnable init, final BooleanSupplier until) {
         return CommandRobot.parallel(name, new InstantCommand(init, this), new WaitUntilCommand(until));
     }
 
@@ -111,7 +114,7 @@ public abstract class SmartSubsystem extends SubsystemBase implements Resettable
      * @param func  The function to call.
      * @return A new command.
      */
-    public <T> CommandBase setter(final String name, final T value, final Consumer<T> func) {
+    default <T> CommandBase setter(final String name, final T value, final Consumer<T> func) {
         return new InstantCommand(() -> {
             func.accept(value);
         }, this).withName(name);
@@ -127,7 +130,7 @@ public abstract class SmartSubsystem extends SubsystemBase implements Resettable
      * @param until The condition to wait until.
      * @return A new command.
      */
-    public <T> CommandBase callAndWait(final String name, final T value, final Consumer<T> func,
+    default <T> CommandBase callAndWait(final String name, final T value, final Consumer<T> func,
             final BooleanSupplier until) {
         return initAndWait(name, () -> {
             func.accept(value);
@@ -139,8 +142,8 @@ public abstract class SmartSubsystem extends SubsystemBase implements Resettable
      * 
      * @return A reset command.
      */
-    public CommandBase resetCmd() {
-        return instant("Reset " + getName(), this::reset);
+    default CommandBase resetCmd() {
+        return instant("Reset " + SendableRegistry.getName(this), this::reset);
     }
 
     /**
@@ -148,8 +151,8 @@ public abstract class SmartSubsystem extends SubsystemBase implements Resettable
      * 
      * @return A cancel command.
      */
-    public CommandBase cancel() {
-        return instant("Cancel " + getName(), () -> {
+    default CommandBase cancel() {
+        return instant("Cancel " + SendableRegistry.getName(this), () -> {
         });
     }
 }

--- a/src/main/java/com/chopshop166/chopshoplib/commands/SmartSubsystemBase.java
+++ b/src/main/java/com/chopshop166/chopshoplib/commands/SmartSubsystemBase.java
@@ -1,0 +1,9 @@
+package com.chopshop166.chopshoplib.commands;
+
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+/**
+ * A {@link SmartSubsystem} that provides all the necessary convenience methods.
+ */
+public abstract class SmartSubsystemBase extends SubsystemBase implements SmartSubsystem {
+}

--- a/src/main/java/com/chopshop166/chopshoplib/states/StateSubsystem.java
+++ b/src/main/java/com/chopshop166/chopshoplib/states/StateSubsystem.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import com.chopshop166.chopshoplib.commands.SmartSubsystem;
+import com.chopshop166.chopshoplib.commands.SmartSubsystemBase;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
@@ -20,7 +20,7 @@ import edu.wpi.first.wpilibj2.command.Subsystem;
  * 
  * @param <S> The enum of possible states.
  */
-public abstract class StateSubsystem<S extends Enum<S>> extends SmartSubsystem {
+public abstract class StateSubsystem<S extends Enum<S>> extends SmartSubsystemBase {
     /** The current subsystem state. */
     private S currentState;
     /** The valid transitions. */


### PR DESCRIPTION
Base was added as a convenience to not require user code to both extend and implement - but since it doesn't add any functionality it allowed Preset subsystem to exist