### PR TITLE
Clean up Motor API

### DIFF
--- a/core/src/main/java/com/chopshop166/chopshoplib/motors/PIDControlType.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/motors/PIDControlType.java
@@ -5,9 +5,5 @@ public enum PIDControlType {
     /** Velocity based PID. */
     Velocity,
     /** Position based PID. */
-    Position,
-    /** Voltage */
-    Voltage,
-    /** Smart Motion. */
-    SmartMotion
+    Position;
 }

--- a/core/src/main/java/com/chopshop166/chopshoplib/motors/PIDSparkMax.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/motors/PIDSparkMax.java
@@ -90,11 +90,16 @@ public class PIDSparkMax extends SmartMotorController {
             this.savedControlType = CANSparkMax.ControlType.kPosition;
         } else if (controlType == PIDControlType.Velocity) {
             this.savedControlType = CANSparkMax.ControlType.kVelocity;
-        } else if (controlType == PIDControlType.SmartMotion) {
-            this.savedControlType = CANSparkMax.ControlType.kSmartMotion;
-        } else if (controlType == PIDControlType.Voltage) {
-            this.savedControlType = CANSparkMax.ControlType.kVoltage;
         }
+    }
+
+    /**
+     * Set the control type to a nonstandard one.
+     *
+     * @param controlType The controlType to set.
+     */
+    public void setControlType(final CANSparkMax.ControlType controlType) {
+        this.savedControlType = controlType;
     }
 
     /**

--- a/core/src/main/java/com/chopshop166/chopshoplib/motors/PIDTalonBase.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/motors/PIDTalonBase.java
@@ -53,6 +53,15 @@ public class PIDTalonBase<T extends BaseTalon & MotorController & Sendable> exte
     }
 
     /**
+     * Set the control type to a nonstandard one.
+     *
+     * @param controlType The controlType to set.
+     */
+    public void setControlType(final ControlMode controlType) {
+        this.savedControlType = controlType;
+    }
+
+    /**
      * Get the control mode of the Talon.
      *
      * @return The control mode.

--- a/core/src/main/java/com/chopshop166/chopshoplib/motors/PIDTalonBase.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/motors/PIDTalonBase.java
@@ -5,7 +5,6 @@ import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.can.BaseTalon;
 
 import edu.wpi.first.util.sendable.Sendable;
-import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.wpilibj.motorcontrol.MotorController;
 
 /**
@@ -25,7 +24,7 @@ public class PIDTalonBase<T extends BaseTalon & MotorController & Sendable> exte
      * @param resolution The number of ticks per revolution.
      */
     public PIDTalonBase(final T wrapped, final double resolution) {
-        super(new MockMotorController(), new TalonEncoder(wrapped, resolution));
+        super(wrapped, new TalonEncoder(wrapped, resolution));
         this.wrapped = wrapped;
     }
 
@@ -71,16 +70,6 @@ public class PIDTalonBase<T extends BaseTalon & MotorController & Sendable> exte
     }
 
     @Override
-    public void set(final double speed) {
-        wrapped.set(speed);
-    }
-
-    @Override
-    public double get() {
-        return wrapped.get();
-    }
-
-    @Override
     public TalonEncoder getEncoder() {
         // This cast is safe because we're the ones setting it in the first place.
         return (TalonEncoder) super.getEncoder();
@@ -89,10 +78,5 @@ public class PIDTalonBase<T extends BaseTalon & MotorController & Sendable> exte
     @Override
     public void setSetpoint(final double setPoint) {
         wrapped.set(savedControlType, setPoint);
-    }
-
-    @Override
-    public void initSendable(final SendableBuilder builder) {
-        wrapped.initSendable(builder);
     }
 }

--- a/kotlinext/src/main/java/com/chopshop166/chopshoplib/motors/Motors.kt
+++ b/kotlinext/src/main/java/com/chopshop166/chopshoplib/motors/Motors.kt
@@ -55,6 +55,4 @@ fun <T> T.withPID(
     when (controlType) {
         PIDControlType.Position -> SwPIDMotorController.position(this, pid, encoder)
         PIDControlType.Velocity -> SwPIDMotorController.velocity(this, pid, encoder)
-        // SmartMotion isn't a thing outside of the Spark MAX
-        else -> SwPIDMotorController.position(this, pid, encoder)
     }.apply(block)


### PR DESCRIPTION
Common enum is for common types only.
Any unusual ones can use the drop-through functionality