### PR TITLE
Reintroduce Commandable as Command Builder

### DIFF
--- a/core/src/main/java/com/chopshop166/chopshoplib/commands/CommandBuilder.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/commands/CommandBuilder.java
@@ -1,0 +1,322 @@
+package com.chopshop166.chopshoplib.commands;
+
+import java.util.Map;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import edu.wpi.first.wpilibj.motorcontrol.MotorController;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.CommandGroupBase;
+import edu.wpi.first.wpilibj2.command.ConditionalCommand;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.ProxyScheduleCommand;
+import edu.wpi.first.wpilibj2.command.RunCommand;
+import edu.wpi.first.wpilibj2.command.SelectCommand;
+import edu.wpi.first.wpilibj2.command.StartEndCommand;
+import edu.wpi.first.wpilibj2.command.Subsystem;
+import edu.wpi.first.wpilibj2.command.WaitCommand;
+import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
+
+/**
+ * Creator for commands.
+ */
+public class CommandBuilder {
+
+    /**
+     * Repeat a {@link Command} a given number of times.
+     *
+     * @param name          The name of the command.
+     * @param numTimesToRun The number of times to run the command.
+     * @param cmd           The command to repeat.
+     * @return A newly constructed command.
+     */
+    public CommandBase repeat(final String name, final int numTimesToRun, final Command cmd) {
+        return repeat(numTimesToRun, cmd).withName(name);
+    }
+
+    /**
+     * Repeat a {@link Command} a given number of times.
+     *
+     * @param numTimesToRun The number of times to run the command.
+     * @param cmd           The command to repeat.
+     * @return A newly constructed command.
+     */
+    public CommandBase repeat(final int numTimesToRun, final Command cmd) {
+        return repeat(numTimesToRun, () -> new ProxyScheduleCommand(cmd));
+    }
+
+    /**
+     * Repeat a {@link Command} a given number of times.
+     *
+     * @param name          The name of the command.
+     * @param numTimesToRun The number of times to run the command.
+     * @param cmd           A way to create the command to repeat.
+     * @return A newly constructed command group.
+     */
+    public CommandBase repeat(final String name, final int numTimesToRun, final Supplier<Command> cmd) {
+        return repeat(numTimesToRun, cmd).withName(name);
+    }
+
+    /**
+     * Repeat a {@link Command} a given number of times.
+     *
+     * @param numTimesToRun The number of times to run the command.
+     * @param cmd           A way to create the command to repeat.
+     * @return A newly constructed command group.
+     */
+    public CommandBase repeat(final int numTimesToRun, final Supplier<Command> cmd) {
+        return CommandGroupBase.sequence(Stream.generate(cmd).limit(numTimesToRun).toArray(Command[]::new));
+    }
+
+    /**
+     * Create a command builder with a given name.
+     *
+     * @param name         The command name.
+     * @param requirements The subsystems that the command needs (can be empty).
+     * @return A new command builder.
+     */
+    public BuildCommand cmd(final String name, final Subsystem... requirements) {
+        return new BuildCommand(name, requirements);
+    }
+
+    /**
+     * Create an {@link InstantCommand}.
+     *
+     * @param name   The name of the command.
+     * @param action The action to take.
+     * @return A new command.
+     */
+    public CommandBase instant(final String name, final Runnable action) {
+        return new InstantCommand(action).withName(name);
+    }
+
+    /**
+     * Create a {@link RunCommand}.
+     *
+     * @param name   The name of the command.
+     * @param action The action to take.
+     * @return A new command.
+     */
+    public CommandBase running(final String name, final Runnable action) {
+        return new RunCommand(action).withName(name);
+    }
+
+    /**
+     * Create a {@link StartEndCommand}.
+     *
+     * @param name    The name of the command.
+     * @param onStart The action to take on start.
+     * @param onEnd   The action to take on end.
+     * @return A new command.
+     */
+    public CommandBase startEnd(final String name, final Runnable onStart, final Runnable onEnd) {
+        return new StartEndCommand(onStart, onEnd).withName(name);
+    }
+
+    /**
+     * Wait until a condition is true.
+     *
+     * @param name  The name of the command.
+     * @param until The condition to wait until.
+     * @return A new command.
+     */
+    public CommandBase waitUntil(final String name, final BooleanSupplier until) {
+        return new WaitUntilCommand(until).withName(name);
+    }
+
+    /**
+     * Run a {@link Runnable} and then wait until a condition is true.
+     *
+     * @param name  The name of the command.
+     * @param init  The action to take.
+     * @param until The condition to wait until.
+     * @return A new command.
+     */
+    public CommandBase initAndWait(final String name, final Runnable init, final BooleanSupplier until) {
+        return parallel(name, new InstantCommand(init), new WaitUntilCommand(until));
+    }
+
+    /**
+     * Create a command to call a consumer function.
+     *
+     * @param <T>   The type to wrap.
+     * @param name  The name of the command.
+     * @param value The value to call the function with.
+     * @param func  The function to call.
+     * @return A new command.
+     */
+    public <T> CommandBase setter(final String name, final T value, final Consumer<T> func) {
+        return instant(name, () -> {
+            func.accept(value);
+        });
+    }
+
+    /**
+     * Create a command that sets a motor to a speed while the command is running.
+     *
+     * @param name  The name of the command.
+     * @param value The value to set the motor to.
+     * @param motor The motor to use.
+     * @return A new command.
+     */
+    public CommandBase runWhile(final String name, final double value, final MotorController motor) {
+        return startEnd(name, () -> {
+            motor.set(value);
+        }, motor::stopMotor);
+    }
+
+    /**
+     * Create a command to call a consumer function and wait.
+     *
+     * @param <T>   The type to wrap.
+     * @param name  The name of the command.
+     * @param value The value to call the function with.
+     * @param func  The function to call.
+     * @param until The condition to wait until.
+     * @return A new command.
+     */
+    public <T> CommandBase callAndWait(final String name, final T value, final Consumer<T> func,
+            final BooleanSupplier until) {
+        return initAndWait(name, () -> {
+            func.accept(value);
+        }, until);
+    }
+
+    /**
+     * Create a sequential command group with a name.
+     *
+     * @param name The name of the command group.
+     * @param cmds The commands to sequence.
+     * @return A new command group.
+     */
+    public CommandBase sequence(final String name, final Command... cmds) {
+        return CommandGroupBase.sequence(cmds).withName(name);
+    }
+
+    /**
+     * Create a parallel command group with a name.
+     *
+     * @param name The name of the command group.
+     * @param cmds The commands to run in parallel.
+     * @return A new command group.
+     */
+    public CommandBase parallel(final String name, final Command... cmds) {
+        return CommandGroupBase.parallel(cmds).withName(name);
+    }
+
+    /**
+     * Create a racing command group with a name.
+     *
+     * @param name   The name of the command group.
+     * @param racers The commands to race.
+     * @return A new command group.
+     */
+    public CommandBase race(final String name, final Command... racers) {
+        return CommandGroupBase.race(racers).withName(name);
+    }
+
+    /**
+     * Create a deadline-limited command group with a name.
+     *
+     * @param name    The name of the command group.
+     * @param limiter The deadline command.
+     * @param cmds    The commands to run until the deadline ends.
+     * @return A new command group.
+     */
+    public CommandBase deadline(final String name, final Command limiter, final Command... cmds) {
+        return CommandGroupBase.deadline(limiter, cmds).withName(name);
+    }
+
+    /**
+     * Create a conditional command.
+     *
+     * @param condition The condition to test.
+     * @param onTrue    The command to run if the condition is true.
+     * @param onFalse   The command to run if the condition is false.
+     * @return The conditional command.
+     */
+    public CommandBase conditional(final BooleanSupplier condition, final Command onTrue, final Command onFalse) {
+        return new ConditionalCommand(onTrue, onFalse, condition);
+    }
+
+    /**
+     * Create a command that runs only if a condition is true.
+     * 
+     * @param condition The condition to test beforehand.
+     * @param cmd       The command to run.
+     * @return The conditional command.
+     */
+    public CommandBase runIf(final BooleanSupplier condition, final Command cmd) {
+        return conditional(condition, cmd, new InstantCommand());
+    }
+
+    /**
+     * Create a command that selects which command to run from a map.
+     *
+     * @param name     The command's name.
+     * @param commands The possible commands to run.
+     * @param selector The function to determine which command should be run.
+     * @return The wrapper command object.
+     */
+    public CommandBase select(final String name, final Map<Object, Command> commands,
+            final Supplier<Object> selector) {
+        return new SelectCommand(commands, selector).withName(name);
+    }
+
+    /**
+     * Create a command that selects which command to run from a function.
+     *
+     * @param name     The command's name.
+     * @param selector The function to determine which command should be run.
+     * @return The wrapper command object.
+     */
+    public CommandBase select(final String name, final Supplier<Command> selector) {
+        return new SelectCommand(selector).withName(name);
+    }
+
+    /**
+     * Create a command to run at regular intervals.
+     * 
+     * @param timeDelta Time in seconds to wait between calls.
+     * @param periodic  The runnable to execute.
+     * @return A new command.
+     */
+    public CommandBase every(final double timeDelta, final Runnable periodic) {
+        return new IntervalCommand(timeDelta, periodic);
+    }
+
+    /**
+     * Create a command that waits for the duration provided by a DoubleSupplier
+     * 
+     * @param name             The command's name
+     * @param durationSupplier Function that returns the number of seconds to wait
+     * @return The wait command
+     */
+    public CommandBase waitFor(final String name, final DoubleSupplier durationSupplier) {
+        return new FunctionalWaitCommand(name, durationSupplier);
+    }
+
+    /**
+     * Create a command that waits for the duration provided by a DoubleSupplier
+     * 
+     * @param durationSupplier Function that returns the number of seconds to wait
+     * @return The wait command
+     */
+    public CommandBase waitFor(final DoubleSupplier durationSupplier) {
+        return new FunctionalWaitCommand(durationSupplier);
+    }
+
+    /**
+     * Create a WaitCommand
+     * 
+     * @param duration The duration in seconds
+     * @return The wait command
+     */
+    public CommandBase waitFor(final double duration) {
+        return new WaitCommand(duration);
+    }
+}

--- a/core/src/main/java/com/chopshop166/chopshoplib/commands/CommandRobot.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/commands/CommandRobot.java
@@ -4,11 +4,6 @@ import java.io.IOException;
 import java.lang.reflect.AccessibleObject;
 import java.net.URL;
 import java.util.Arrays;
-import java.util.Map;
-import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
-import java.util.function.DoubleSupplier;
-import java.util.function.Supplier;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.stream.Stream;
@@ -21,23 +16,12 @@ import com.google.common.reflect.ClassPath;
 
 import edu.wpi.first.math.Pair;
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj.motorcontrol.MotorController;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import edu.wpi.first.wpilibj2.command.CommandGroupBase;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import edu.wpi.first.wpilibj2.command.ConditionalCommand;
-import edu.wpi.first.wpilibj2.command.InstantCommand;
-import edu.wpi.first.wpilibj2.command.ProxyScheduleCommand;
-import edu.wpi.first.wpilibj2.command.RunCommand;
-import edu.wpi.first.wpilibj2.command.SelectCommand;
-import edu.wpi.first.wpilibj2.command.StartEndCommand;
-import edu.wpi.first.wpilibj2.command.Subsystem;
-import edu.wpi.first.wpilibj2.command.WaitCommand;
-import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
 
 /**
  * A Robot that calls the command scheduler in its periodic functions.
@@ -53,6 +37,8 @@ public abstract class CommandRobot extends TimedRobot {
     final private SendableChooser<Command> autoChooser = new SendableChooser<>();
     /** Currently running autonomous command. */
     private Command autoCmd;
+    /** Command accessor. */
+    protected final CommandBuilder make = new CommandBuilder();
 
     /** Set up the button bindings. */
     public abstract void configureButtonBindings();
@@ -171,7 +157,7 @@ public abstract class CommandRobot extends TimedRobot {
      * @return A command
      */
     public CommandBase resetSubsystems(final SmartSubsystem... subsystems) {
-        return parallel("Reset Subsystems",
+        return make.parallel("Reset Subsystems",
                 Stream.of(subsystems).map(SmartSubsystem::resetCmd).toArray(CommandBase[]::new));
     }
 
@@ -182,7 +168,7 @@ public abstract class CommandRobot extends TimedRobot {
      * @return A command
      */
     public CommandBase safeStateSubsystems(final SmartSubsystem... subsystems) {
-        return parallel("Reset Subsystems",
+        return make.parallel("Reset Subsystems",
                 Stream.of(subsystems).map(SmartSubsystem::safeStateCmd).toArray(CommandBase[]::new));
     }
 
@@ -313,302 +299,5 @@ public abstract class CommandRobot extends TimedRobot {
             return UNKNOWN_VALUE;
         }
     }
-
-    // #region Commands
-
-    /**
-     * Repeat a {@link Command} a given number of times.
-     *
-     * @param name          The name of the command.
-     * @param numTimesToRun The number of times to run the command.
-     * @param cmd           The command to repeat.
-     * @return A newly constructed command.
-     */
-    protected CommandBase repeat(final String name, final int numTimesToRun, final Command cmd) {
-        return repeat(numTimesToRun, cmd).withName(name);
-    }
-
-    /**
-     * Repeat a {@link Command} a given number of times.
-     *
-     * @param numTimesToRun The number of times to run the command.
-     * @param cmd           The command to repeat.
-     * @return A newly constructed command.
-     */
-    protected CommandBase repeat(final int numTimesToRun, final Command cmd) {
-        return repeat(numTimesToRun, () -> new ProxyScheduleCommand(cmd));
-    }
-
-    /**
-     * Repeat a {@link Command} a given number of times.
-     *
-     * @param name          The name of the command.
-     * @param numTimesToRun The number of times to run the command.
-     * @param cmd           A way to create the command to repeat.
-     * @return A newly constructed command group.
-     */
-    protected CommandBase repeat(final String name, final int numTimesToRun, final Supplier<Command> cmd) {
-        return repeat(numTimesToRun, cmd).withName(name);
-    }
-
-    /**
-     * Repeat a {@link Command} a given number of times.
-     *
-     * @param numTimesToRun The number of times to run the command.
-     * @param cmd           A way to create the command to repeat.
-     * @return A newly constructed command group.
-     */
-    protected CommandBase repeat(final int numTimesToRun, final Supplier<Command> cmd) {
-        return CommandGroupBase.sequence(Stream.generate(cmd).limit(numTimesToRun).toArray(Command[]::new));
-    }
-
-    /**
-     * Create a command builder with a given name.
-     *
-     * @param name         The command name.
-     * @param requirements The subsystems that the command needs (can be empty).
-     * @return A new command builder.
-     */
-    protected BuildCommand cmd(final String name, final Subsystem... requirements) {
-        return new BuildCommand(name, requirements);
-    }
-
-    /**
-     * Create an {@link InstantCommand}.
-     *
-     * @param name   The name of the command.
-     * @param action The action to take.
-     * @return A new command.
-     */
-    protected CommandBase instant(final String name, final Runnable action) {
-        return new InstantCommand(action).withName(name);
-    }
-
-    /**
-     * Create a {@link RunCommand}.
-     *
-     * @param name   The name of the command.
-     * @param action The action to take.
-     * @return A new command.
-     */
-    protected CommandBase running(final String name, final Runnable action) {
-        return new RunCommand(action).withName(name);
-    }
-
-    /**
-     * Create a {@link StartEndCommand}.
-     *
-     * @param name    The name of the command.
-     * @param onStart The action to take on start.
-     * @param onEnd   The action to take on end.
-     * @return A new command.
-     */
-    protected CommandBase startEnd(final String name, final Runnable onStart, final Runnable onEnd) {
-        return new StartEndCommand(onStart, onEnd).withName(name);
-    }
-
-    /**
-     * Wait until a condition is true.
-     *
-     * @param name  The name of the command.
-     * @param until The condition to wait until.
-     * @return A new command.
-     */
-    protected CommandBase waitUntil(final String name, final BooleanSupplier until) {
-        return new WaitUntilCommand(until).withName(name);
-    }
-
-    /**
-     * Run a {@link Runnable} and then wait until a condition is true.
-     *
-     * @param name  The name of the command.
-     * @param init  The action to take.
-     * @param until The condition to wait until.
-     * @return A new command.
-     */
-    protected CommandBase initAndWait(final String name, final Runnable init, final BooleanSupplier until) {
-        return parallel(name, new InstantCommand(init), new WaitUntilCommand(until));
-    }
-
-    /**
-     * Create a command to call a consumer function.
-     *
-     * @param <T>   The type to wrap.
-     * @param name  The name of the command.
-     * @param value The value to call the function with.
-     * @param func  The function to call.
-     * @return A new command.
-     */
-    protected <T> CommandBase setter(final String name, final T value, final Consumer<T> func) {
-        return instant(name, () -> {
-            func.accept(value);
-        });
-    }
-
-    /**
-     * Create a command that sets a motor to a speed while the command is running.
-     *
-     * @param name  The name of the command.
-     * @param value The value to set the motor to.
-     * @param motor The motor to use.
-     * @return A new command.
-     */
-    protected CommandBase runWhile(final String name, final double value, final MotorController motor) {
-        return startEnd(name, () -> {
-            motor.set(value);
-        }, motor::stopMotor);
-    }
-
-    /**
-     * Create a command to call a consumer function and wait.
-     *
-     * @param <T>   The type to wrap.
-     * @param name  The name of the command.
-     * @param value The value to call the function with.
-     * @param func  The function to call.
-     * @param until The condition to wait until.
-     * @return A new command.
-     */
-    protected <T> CommandBase callAndWait(final String name, final T value, final Consumer<T> func,
-            final BooleanSupplier until) {
-        return initAndWait(name, () -> {
-            func.accept(value);
-        }, until);
-    }
-
-    /**
-     * Create a sequential command group with a name.
-     *
-     * @param name The name of the command group.
-     * @param cmds The commands to sequence.
-     * @return A new command group.
-     */
-    protected CommandBase sequence(final String name, final Command... cmds) {
-        return CommandGroupBase.sequence(cmds).withName(name);
-    }
-
-    /**
-     * Create a parallel command group with a name.
-     *
-     * @param name The name of the command group.
-     * @param cmds The commands to run in parallel.
-     * @return A new command group.
-     */
-    protected CommandBase parallel(final String name, final Command... cmds) {
-        return CommandGroupBase.parallel(cmds).withName(name);
-    }
-
-    /**
-     * Create a racing command group with a name.
-     *
-     * @param name   The name of the command group.
-     * @param racers The commands to race.
-     * @return A new command group.
-     */
-    protected CommandBase race(final String name, final Command... racers) {
-        return CommandGroupBase.race(racers).withName(name);
-    }
-
-    /**
-     * Create a deadline-limited command group with a name.
-     *
-     * @param name    The name of the command group.
-     * @param limiter The deadline command.
-     * @param cmds    The commands to run until the deadline ends.
-     * @return A new command group.
-     */
-    protected CommandBase deadline(final String name, final Command limiter, final Command... cmds) {
-        return CommandGroupBase.deadline(limiter, cmds).withName(name);
-    }
-
-    /**
-     * Create a conditional command.
-     *
-     * @param condition The condition to test.
-     * @param onTrue    The command to run if the condition is true.
-     * @param onFalse   The command to run if the condition is false.
-     * @return The conditional command.
-     */
-    protected CommandBase conditional(final BooleanSupplier condition, final Command onTrue, final Command onFalse) {
-        return new ConditionalCommand(onTrue, onFalse, condition);
-    }
-
-    /**
-     * Create a command that runs only if a condition is true.
-     * 
-     * @param condition The condition to test beforehand.
-     * @param cmd       The command to run.
-     * @return The conditional command.
-     */
-    protected CommandBase runIf(final BooleanSupplier condition, final Command cmd) {
-        return conditional(condition, cmd, new InstantCommand());
-    }
-
-    /**
-     * Create a command that selects which command to run from a map.
-     *
-     * @param name     The command's name.
-     * @param commands The possible commands to run.
-     * @param selector The function to determine which command should be run.
-     * @return The wrapper command object.
-     */
-    protected CommandBase select(final String name, final Map<Object, Command> commands,
-            final Supplier<Object> selector) {
-        return new SelectCommand(commands, selector).withName(name);
-    }
-
-    /**
-     * Create a command that selects which command to run from a function.
-     *
-     * @param name     The command's name.
-     * @param selector The function to determine which command should be run.
-     * @return The wrapper command object.
-     */
-    protected CommandBase select(final String name, final Supplier<Command> selector) {
-        return new SelectCommand(selector).withName(name);
-    }
-
-    /**
-     * Create a command to run at regular intervals.
-     * 
-     * @param timeDelta Time in seconds to wait between calls.
-     * @param periodic  The runnable to execute.
-     * @return A new command.
-     */
-    protected CommandBase every(final double timeDelta, final Runnable periodic) {
-        return new IntervalCommand(timeDelta, periodic);
-    }
-
-    /**
-     * Create a command that waits for the duration provided by a DoubleSupplier
-     * 
-     * @param name             The command's name
-     * @param durationSupplier Function that returns the number of seconds to wait
-     * @return The wait command
-     */
-    protected CommandBase waitFor(final String name, final DoubleSupplier durationSupplier) {
-        return new FunctionalWaitCommand(name, durationSupplier);
-    }
-
-    /**
-     * Create a command that waits for the duration provided by a DoubleSupplier
-     * 
-     * @param durationSupplier Function that returns the number of seconds to wait
-     * @return The wait command
-     */
-    protected CommandBase waitFor(final DoubleSupplier durationSupplier) {
-        return new FunctionalWaitCommand(durationSupplier);
-    }
-
-    /**
-     * Create a WaitCommand
-     * 
-     * @param duration The duration in seconds
-     * @return The wait command
-     */
-    protected CommandBase waitFor(final double duration) {
-        return new WaitCommand(duration);
-    }
-    // #endregion
 
 }

--- a/core/src/main/java/com/chopshop166/chopshoplib/commands/PresetSubsystem.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/commands/PresetSubsystem.java
@@ -6,10 +6,7 @@ import com.chopshop166.chopshoplib.PersistenceCheck;
 
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import edu.wpi.first.wpilibj2.command.CommandGroupBase;
-import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.PIDSubsystem;
-import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
 
 /**
  * A {@link PIDSubsystem} that has several presets that it can go to.
@@ -17,6 +14,8 @@ import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
 public abstract class PresetSubsystem<T extends Enum<?> & DoubleSupplier> extends PIDSubsystem
         implements SmartSubsystem {
 
+    /** Builder for commands. */
+    protected CommandBuilder make = new SubsystemCommandBuilder(this);
     /** Check to make sure it's at the setpoint for enough time. */
     private final PersistenceCheck persistenceCheck;
 
@@ -50,9 +49,9 @@ public abstract class PresetSubsystem<T extends Enum<?> & DoubleSupplier> extend
      * @return The instant command.
      */
     public CommandBase presetCmd(final T value) {
-        return new InstantCommand(() -> {
+        return make.instant("Set to " + value.name(), () -> {
             setSetpoint(value.getAsDouble());
-        }, this).withName("Set to " + value.name());
+        });
     }
 
     /**
@@ -61,7 +60,7 @@ public abstract class PresetSubsystem<T extends Enum<?> & DoubleSupplier> extend
      * @return The wait command.
      */
     public CommandBase waitForSetpoint() {
-        return new WaitUntilCommand(persistenceCheck).withName("Wait For Setpoint");
+        return make.waitUntil("Wait For Setpoint", persistenceCheck);
     }
 
     /**
@@ -71,7 +70,7 @@ public abstract class PresetSubsystem<T extends Enum<?> & DoubleSupplier> extend
      * @return The instant command.
      */
     public CommandBase presetWait(final T value) {
-        return CommandGroupBase.sequence(presetCmd(value), waitForSetpoint()).withName("Set to " + value.name());
+        return make.sequence("Set to " + value.name(), presetCmd(value), waitForSetpoint());
     }
 
     @Override

--- a/core/src/main/java/com/chopshop166/chopshoplib/commands/SmartSubsystem.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/commands/SmartSubsystem.java
@@ -22,7 +22,7 @@ public interface SmartSubsystem extends Subsystem, HasSafeState, Resettable, Sen
      * @return A reset command.
      */
     default CommandBase resetCmd() {
-        return new InstantCommand(this::reset).withName("Reset " + SendableRegistry.getName(this));
+        return new InstantCommand(this::reset, this).withName("Reset " + SendableRegistry.getName(this));
     }
 
     /**
@@ -31,7 +31,7 @@ public interface SmartSubsystem extends Subsystem, HasSafeState, Resettable, Sen
      * @return A reset command.
      */
     default CommandBase safeStateCmd() {
-        return new InstantCommand(this::safeState).withName("Safe " + SendableRegistry.getName(this));
+        return new InstantCommand(this::safeState, this).withName("Safe " + SendableRegistry.getName(this));
     }
 
     /**
@@ -41,6 +41,6 @@ public interface SmartSubsystem extends Subsystem, HasSafeState, Resettable, Sen
      */
     default CommandBase cancel() {
         return new InstantCommand(() -> {
-        }).withName("Cancel " + SendableRegistry.getName(this));
+        }, this).withName("Cancel " + SendableRegistry.getName(this));
     }
 }

--- a/core/src/main/java/com/chopshop166/chopshoplib/commands/SmartSubsystemBase.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/commands/SmartSubsystemBase.java
@@ -1,322 +1,45 @@
 package com.chopshop166.chopshoplib.commands;
 
-import java.util.Map;
-import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
-import java.util.function.DoubleSupplier;
-import java.util.stream.Stream;
-
-import com.google.common.base.Supplier;
-
-import edu.wpi.first.wpilibj.motorcontrol.MotorController;
-import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import edu.wpi.first.wpilibj2.command.CommandGroupBase;
-import edu.wpi.first.wpilibj2.command.ConditionalCommand;
-import edu.wpi.first.wpilibj2.command.InstantCommand;
-import edu.wpi.first.wpilibj2.command.ProxyScheduleCommand;
-import edu.wpi.first.wpilibj2.command.RunCommand;
-import edu.wpi.first.wpilibj2.command.SelectCommand;
-import edu.wpi.first.wpilibj2.command.StartEndCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import edu.wpi.first.wpilibj2.command.WaitCommand;
-import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
 
 /**
  * A {@link SmartSubsystem} that provides all the necessary convenience methods.
  */
 public abstract class SmartSubsystemBase extends SubsystemBase implements SmartSubsystem {
 
-    /**
-     * Repeat a {@link Command} a given number of times.
-     *
-     * @param name          The name of the command.
-     * @param numTimesToRun The number of times to run the command.
-     * @param cmd           The command to repeat.
-     * @return A newly constructed command.
-     */
-    protected CommandBase repeat(final String name, final int numTimesToRun, final Command cmd) {
-        return repeat(numTimesToRun, cmd).withName(name);
-    }
+    /** Builder for commands. */
+    protected CommandBuilder make = new SubsystemCommandBuilder(this);
 
     /**
-     * Repeat a {@link Command} a given number of times.
-     *
-     * @param numTimesToRun The number of times to run the command.
-     * @param cmd           The command to repeat.
-     * @return A newly constructed command.
-     */
-    protected CommandBase repeat(final int numTimesToRun, final Command cmd) {
-        return repeat(numTimesToRun, () -> new ProxyScheduleCommand(cmd));
-    }
-
-    /**
-     * Repeat a {@link Command} a given number of times.
-     *
-     * @param name          The name of the command.
-     * @param numTimesToRun The number of times to run the command.
-     * @param cmd           A way to create the command to repeat.
-     * @return A newly constructed command group.
-     */
-    protected CommandBase repeat(final String name, final int numTimesToRun, final Supplier<Command> cmd) {
-        return repeat(numTimesToRun, cmd).withName(name);
-    }
-
-    /**
-     * Repeat a {@link Command} a given number of times.
-     *
-     * @param numTimesToRun The number of times to run the command.
-     * @param cmd           A way to create the command to repeat.
-     * @return A newly constructed command group.
-     */
-    protected CommandBase repeat(final int numTimesToRun, final Supplier<Command> cmd) {
-        return CommandGroupBase.sequence(Stream.generate(cmd).limit(numTimesToRun).toArray(Command[]::new));
-    }
-
-    /**
-     * Create a command builder with a given name.
-     *
-     * @param name The command name.
-     * @return A new command builder.
-     */
-    protected BuildCommand cmd(final String name) {
-        return new BuildCommand(name, this);
-    }
-
-    /**
-     * Create an {@link InstantCommand}.
+     * Create a command to reset the subsystem.
      * 
-     * @param name   The name of the command.
-     * @param action The action to take.
-     * @return A new command.
+     * @return A reset command.
      */
-    protected CommandBase instant(final String name, final Runnable action) {
-        return new InstantCommand(action, this).withName(name);
+    @Override
+    public CommandBase resetCmd() {
+        return make.instant("Reset " + SendableRegistry.getName(this), this::reset);
     }
 
     /**
-     * Create a {@link RunCommand}.
-     *
-     * @param name   The name of the command.
-     * @param action The action to take.
-     * @return A new command.
+     * Create a command to reset the subsystem.
+     * 
+     * @return A reset command.
      */
-    protected CommandBase running(final String name, final Runnable action) {
-        return new RunCommand(action, this).withName(name);
+    @Override
+    public CommandBase safeStateCmd() {
+        return make.instant("Safe " + SendableRegistry.getName(this), this::safeState);
     }
 
     /**
-     * Create a {@link StartEndCommand}.
-     *
-     * @param name    The name of the command.
-     * @param onStart The action to take on start.
-     * @param onEnd   The action to take on end.
-     * @return A new command.
+     * Cancel the currently running command.
+     * 
+     * @return A cancel command.
      */
-    protected CommandBase startEnd(final String name, final Runnable onStart, final Runnable onEnd) {
-        return new StartEndCommand(onStart, onEnd, this).withName(name);
-    }
-
-    /**
-     * Wait until a condition is true.
-     *
-     * @param name  The name of the command.
-     * @param until The condition to wait until.
-     * @return A new command.
-     */
-    protected CommandBase waitUntil(final String name, final BooleanSupplier until) {
-        return new WaitUntilCommand(until).withName(name);
-    }
-
-    /**
-     * Run a {@link Runnable} and then wait until a condition is true.
-     *
-     * @param name  The name of the command.
-     * @param init  The action to take.
-     * @param until The condition to wait until.
-     * @return A new command.
-     */
-    protected CommandBase initAndWait(final String name, final Runnable init, final BooleanSupplier until) {
-        return parallel(name, new InstantCommand(init, this), new WaitUntilCommand(until));
-    }
-
-    /**
-     * Create a command to call a consumer function.
-     *
-     * @param <T>   The type to wrap.
-     * @param name  The name of the command.
-     * @param value The value to call the function with.
-     * @param func  The function to call.
-     * @return A new command.
-     */
-    protected <T> CommandBase setter(final String name, final T value, final Consumer<T> func) {
-        return instant(name, () -> {
-            func.accept(value);
+    @Override
+    public CommandBase cancel() {
+        return make.instant("Cancel " + SendableRegistry.getName(this), () -> {
         });
-    }
-
-    /**
-     * Create a command that sets a motor to a speed while the command is running.
-     *
-     * @param name  The name of the command.
-     * @param value The value to set the motor to.
-     * @param motor The motor to use.
-     * @return A new command.
-     */
-    protected CommandBase runWhile(final String name, final double value, final MotorController motor) {
-        return startEnd(name, () -> {
-            motor.set(value);
-        }, motor::stopMotor);
-    }
-
-    /**
-     * Create a command to call a consumer function and wait.
-     *
-     * @param <T>   The type to wrap.
-     * @param name  The name of the command.
-     * @param value The value to call the function with.
-     * @param func  The function to call.
-     * @param until The condition to wait until.
-     * @return A new command.
-     */
-    protected <T> CommandBase callAndWait(final String name, final T value, final Consumer<T> func,
-            final BooleanSupplier until) {
-        return initAndWait(name, () -> {
-            func.accept(value);
-        }, until);
-    }
-
-    /**
-     * Create a sequential command group with a name.
-     *
-     * @param name The name of the command group.
-     * @param cmds The commands to sequence.
-     * @return A new command group.
-     */
-    protected CommandBase sequence(final String name, final Command... cmds) {
-        return CommandGroupBase.sequence(cmds).withName(name);
-    }
-
-    /**
-     * Create a parallel command group with a name.
-     *
-     * @param name The name of the command group.
-     * @param cmds The commands to run in parallel.
-     * @return A new command group.
-     */
-    protected CommandBase parallel(final String name, final Command... cmds) {
-        return CommandGroupBase.parallel(cmds).withName(name);
-    }
-
-    /**
-     * Create a racing command group with a name.
-     *
-     * @param name   The name of the command group.
-     * @param racers The commands to race.
-     * @return A new command group.
-     */
-    protected CommandBase race(final String name, final Command... racers) {
-        return CommandGroupBase.race(racers).withName(name);
-    }
-
-    /**
-     * Create a deadline-limited command group with a name.
-     *
-     * @param name    The name of the command group.
-     * @param limiter The deadline command.
-     * @param cmds    The commands to run until the deadline ends.
-     * @return A new command group.
-     */
-    protected CommandBase deadline(final String name, final Command limiter, final Command... cmds) {
-        return CommandGroupBase.deadline(limiter, cmds).withName(name);
-    }
-
-    /**
-     * Create a conditional command.
-     *
-     * @param condition The condition to test.
-     * @param onTrue    The command to run if the condition is true.
-     * @param onFalse   The command to run if the condition is false.
-     * @return The conditional command.
-     */
-    protected CommandBase conditional(final BooleanSupplier condition, final Command onTrue, final Command onFalse) {
-        return new ConditionalCommand(onTrue, onFalse, condition);
-    }
-
-    /**
-     * Create a command that runs only if a condition is true.
-     * 
-     * @param condition The condition to test beforehand.
-     * @param cmd       The command to run.
-     * @return The conditional command.
-     */
-    protected CommandBase runIf(final BooleanSupplier condition, final Command cmd) {
-        return conditional(condition, cmd, new InstantCommand());
-    }
-
-    /**
-     * Create a command that selects which command to run from a map.
-     *
-     * @param name     The command's name.
-     * @param commands The possible commands to run.
-     * @param selector The function to determine which command should be run.
-     * @return The wrapper command object.
-     */
-    protected CommandBase select(final String name, final Map<Object, Command> commands,
-            final Supplier<Object> selector) {
-        return new SelectCommand(commands, selector).withName(name);
-    }
-
-    /**
-     * Create a command that selects which command to run from a function.
-     *
-     * @param name     The command's name.
-     * @param selector The function to determine which command should be run.
-     * @return The wrapper command object.
-     */
-    protected CommandBase select(final String name, final Supplier<Command> selector) {
-        return new SelectCommand(selector).withName(name);
-    }
-
-    /**
-     * Create a command to run at regular intervals.
-     * 
-     * @param timeDelta Time in seconds to wait between calls.
-     * @param periodic  The runnable to execute.
-     * @return A new command.
-     */
-    protected CommandBase every(final double timeDelta, final Runnable periodic) {
-        return new IntervalCommand(timeDelta, this, periodic);
-    }
-
-    /**
-     * Create a command that waits for the duration provided by a DoubleSupplier
-     * 
-     * @param name             The command's name
-     * @param durationSupplier Function that returns the number of seconds to wait
-     * @return The wait command
-     */
-    protected CommandBase waitFor(final String name, final DoubleSupplier durationSupplier) {
-        return new FunctionalWaitCommand(name, durationSupplier);
-    }
-
-    /**
-     * Create a command that waits for the duration provided by a DoubleSupplier
-     * 
-     * @param durationSupplier Function that returns the number of seconds to wait
-     * @return The wait command
-     */
-    protected CommandBase waitFor(final DoubleSupplier durationSupplier) {
-        return new FunctionalWaitCommand(durationSupplier);
-    }
-
-    /**
-     * Create a WaitCommand
-     * 
-     * @param duration The duration in seconds
-     * @return The wait command
-     */
-    protected CommandBase waitFor(final double duration) {
-        return new WaitCommand(duration);
     }
 }

--- a/core/src/main/java/com/chopshop166/chopshoplib/commands/SubsystemCommandBuilder.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/commands/SubsystemCommandBuilder.java
@@ -1,0 +1,101 @@
+package com.chopshop166.chopshoplib.commands;
+
+import java.util.function.BooleanSupplier;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.RunCommand;
+import edu.wpi.first.wpilibj2.command.StartEndCommand;
+import edu.wpi.first.wpilibj2.command.Subsystem;
+import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
+
+/**
+ * Creator for commands.
+ */
+public class SubsystemCommandBuilder extends CommandBuilder {
+
+    /** The subsystem that depends on these commands. */
+    private final Subsystem subsystem;
+
+    /**
+     * Constructor.
+     * 
+     * @param subsystem The subsystem that the commands depend on.
+     */
+    public SubsystemCommandBuilder(final Subsystem subsystem) {
+        super();
+        this.subsystem = subsystem;
+    }
+
+    /**
+     * Create a command builder with a given name.
+     * 
+     * @param name The command name.
+     * @return A new command builder.
+     */
+    public BuildCommand cmd(final String name) {
+        return new BuildCommand(name, subsystem);
+    }
+
+    /**
+     * Create an {@link InstantCommand}.
+     * 
+     * @param name   The name of the command.
+     * @param action The action to take.
+     * @return A new command.
+     */
+    @Override
+    public CommandBase instant(final String name, final Runnable action) {
+        return new InstantCommand(action, subsystem).withName(name);
+    }
+
+    /**
+     * Create a {@link RunCommand}.
+     * 
+     * @param name   The name of the command.
+     * @param action The action to take.
+     * @return A new command.
+     */
+    @Override
+    public CommandBase running(final String name, final Runnable action) {
+        return new RunCommand(action, subsystem).withName(name);
+    }
+
+    /**
+     * Create a {@link StartEndCommand}.
+     * 
+     * @param name    The name of the command.
+     * @param onStart The action to take on start.
+     * @param onEnd   The action to take on end.
+     * @return A new command.
+     */
+    @Override
+    public CommandBase startEnd(final String name, final Runnable onStart, final Runnable onEnd) {
+        return new StartEndCommand(onStart, onEnd, subsystem).withName(name);
+    }
+
+    /**
+     * Run a {@link Runnable} and then wait until a condition is true.
+     * 
+     * @param name  The name of the command.
+     * @param init  The action to take.
+     * @param until The condition to wait until.
+     * @return A new command.
+     */
+    @Override
+    public CommandBase initAndWait(final String name, final Runnable init, final BooleanSupplier until) {
+        return parallel(name, new InstantCommand(init, subsystem), new WaitUntilCommand(until));
+    }
+
+    /**
+     * Create a command to run at regular intervals.
+     * 
+     * @param timeDelta Time in seconds to wait between calls.
+     * @param periodic  The runnable to execute.
+     * @return A new command.
+     */
+    @Override
+    public CommandBase every(final double timeDelta, final Runnable periodic) {
+        return new IntervalCommand(timeDelta, subsystem, periodic);
+    }
+}

--- a/core/src/main/java/com/chopshop166/chopshoplib/drive/DiffDriveSubsystem.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/drive/DiffDriveSubsystem.java
@@ -178,7 +178,7 @@ public class DiffDriveSubsystem extends SmartSubsystemBase {
      * @return A command that will run until interrupted.
      */
     public CommandBase drive(final DoubleSupplier forward, final DoubleSupplier turn) {
-        return running("Drive", () -> {
+        return make.running("Drive", () -> {
             final double yAxis = forward.getAsDouble();
             final double xAxis = turn.getAsDouble();
             driveTrain.arcadeDrive(yAxis, xAxis);
@@ -193,7 +193,7 @@ public class DiffDriveSubsystem extends SmartSubsystemBase {
      * @return The command.
      */
     public CommandBase driveDistance(final double distance, final double speed) {
-        return cmd("Drive " + distance + " at " + speed).onInitialize(this::resetEncoders).onExecute(() -> {
+        return make.cmd("Drive " + distance + " at " + speed).onInitialize(this::resetEncoders).onExecute(() -> {
             driveTrain.arcadeDrive(speed, 0);
         }).onEnd(interrupted -> {
             driveTrain.stopMotor();
@@ -210,7 +210,7 @@ public class DiffDriveSubsystem extends SmartSubsystemBase {
      * @return The command.
      */
     public CommandBase turnDegrees(final double degrees, final double speed) {
-        return cmd("Turn Degrees").onInitialize(this::resetGyro).onExecute(() -> {
+        return make.cmd("Turn Degrees").onInitialize(this::resetGyro).onExecute(() -> {
             double realSpeed = speed;
             if (Math.signum(degrees) != Math.signum(speed)) {
                 realSpeed *= -1;

--- a/core/src/main/java/com/chopshop166/chopshoplib/states/StateSubsystem.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/states/StateSubsystem.java
@@ -91,7 +91,7 @@ public abstract class StateSubsystem<S extends Enum<S>> extends SmartSubsystemBa
     public Command changeState(final S newState) {
         final StringBuilder cmdname = new StringBuilder(getName());
         cmdname.append(" -> ").append(newState.name());
-        return setter(cmdname.toString(), newState, this::setState);
+        return make.setter(cmdname.toString(), newState, this::setState);
     }
 
     /**


### PR DESCRIPTION
I had removed `Commandable`, because it shouldn't expose those functions publicly. Unfortunately, it appears that I forgot that the `Auto` class in our setup uses that functionality. So I'm reintroducing it as a member that you call like `make.instant()` instead of just `instant()`.