### PR TITLE
fix: Spark MAX/Flex use right encoder for brushed motors

### DIFF
--- a/core/src/main/java/com/chopshop166/chopshoplib/motors/CSSpark.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/motors/CSSpark.java
@@ -3,7 +3,9 @@ package com.chopshop166.chopshoplib.motors;
 import com.chopshop166.chopshoplib.sensors.SparkEncoder;
 import com.revrobotics.CANSparkBase;
 import com.revrobotics.CANSparkBase.ControlType;
+import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.SparkPIDController;
+import com.revrobotics.SparkRelativeEncoder;
 
 /**
  * CSSpark
@@ -25,9 +27,12 @@ public class CSSpark extends SmartMotorController {
      * Create a smart motor controller from an unwrapped Spark object.
      *
      * @param spark The Spark MAX/Flex oject.
+     * @param type The motor type (brushed vs brushless).
      */
-    public CSSpark(final CANSparkBase spark) {
-        super(new MockMotorController(), new SparkEncoder(spark.getEncoder()));
+    public CSSpark(final CANSparkBase spark, final MotorType type) {
+        super(new MockMotorController(),
+                new SparkEncoder(type == MotorType.kBrushless ? spark.getEncoder()
+                        : spark.getEncoder(SparkRelativeEncoder.Type.kQuadrature, 4096)));
         this.spark = spark;
         this.sparkPID = spark.getPIDController();
     }

--- a/core/src/main/java/com/chopshop166/chopshoplib/motors/CSSparkFlex.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/motors/CSSparkFlex.java
@@ -20,7 +20,7 @@ public class CSSparkFlex extends CSSpark {
      *        to the Red and Black terminals only.
      */
     public CSSparkFlex(final int deviceID, final MotorType type) {
-        super(new CANSparkFlex(deviceID, type));
+        super(new CANSparkFlex(deviceID, type), type);
     }
 
     @Override

--- a/core/src/main/java/com/chopshop166/chopshoplib/motors/CSSparkMax.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/motors/CSSparkMax.java
@@ -20,7 +20,7 @@ public class CSSparkMax extends CSSpark {
      *        to the Red and Black terminals only.
      */
     public CSSparkMax(final int deviceID, final MotorType type) {
-        super(new CANSparkMax(deviceID, type));
+        super(new CANSparkMax(deviceID, type), type);
     }
 
     @Override

--- a/kotlinext/src/main/java/com/chopshop166/chopshoplib/motors/Motors.kt
+++ b/kotlinext/src/main/java/com/chopshop166/chopshoplib/motors/Motors.kt
@@ -5,7 +5,9 @@ import com.chopshop166.chopshoplib.sensors.MockEncoder
 import com.ctre.phoenix.motorcontrol.ControlMode
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX
 import com.ctre.phoenix6.hardware.TalonFX
+import com.revrobotics.CANSparkFlex
 import com.revrobotics.CANSparkMax
+import com.revrobotics.CANSparkLowLevel.MotorType
 import edu.wpi.first.math.controller.PIDController
 import edu.wpi.first.wpilibj.motorcontrol.MotorController
 
@@ -17,11 +19,22 @@ fun MotorController.toSmart(encoder: IEncoder = MockEncoder()) =
 fun CANSparkMax.follow(thisObj: CSSpark, inverted: Boolean = false) =
     follow(thisObj.motorController, inverted)
 
-fun CANSparkMax.withPID(
+fun CANSparkFlex.withPID(
+    motorType : MotorType,
     controlType: PIDControlType = PIDControlType.Velocity,
     block: CSSpark.() -> Unit = {}
 ) =
-    CSSpark(this).apply {
+    CSSpark(this, motorType).apply {
+        setControlType(controlType)
+        block()
+    }
+
+fun CANSparkMax.withPID(
+    motorType : MotorType,
+    controlType: PIDControlType = PIDControlType.Velocity,
+    block: CSSpark.() -> Unit = {}
+) =
+    CSSpark(this, motorType).apply {
         setControlType(controlType)
         block()
     }


### PR DESCRIPTION
Fixes #181 