### PR TITLE
ChopShop wrapper  for analog encoder

### DIFF
--- a/core/src/main/java/com/chopshop166/chopshoplib/sensors/CSAnalogEncoder.java
+++ b/core/src/main/java/com/chopshop166/chopshoplib/sensors/CSAnalogEncoder.java
@@ -1,0 +1,36 @@
+package com.chopshop166.chopshoplib.sensors;
+
+import edu.wpi.first.wpilibj.AnalogEncoder;
+
+// Wrapper class for AnalogEncoder implementing IAbsolutePosition interface
+public class CSAnalogEncoder extends AnalogEncoder implements IAbsolutePosition {
+    private double offset;
+
+    // Constructor that initializes the AnalogEncoder with the specified channel
+    public CSAnalogEncoder(final int channel) {
+        super(channel);
+    }
+
+    public CSAnalogEncoder(final int channel, final double distancePerRotation) {
+        super(channel);
+        setDistancePerRotation(distancePerRotation);
+    }
+
+    public CSAnalogEncoder(final int channel, final double distancePerRotation,
+            final double offset) {
+        super(channel);
+        setDistancePerRotation(distancePerRotation);
+        setOffset(offset);
+    }
+
+    // Override method to get the absolute position from the encoder
+    @Override
+    public double getAbsolutePosition() {
+        return get() + offset;
+    }
+
+    // Method to set the offset
+    public void setOffset(double offset) {
+        this.offset = offset;
+    }
+}


### PR DESCRIPTION
The idea is to create a wrapper that extends WPIlibs analog encoder. But the issue is that I truly have no idea what I'm doing.

From CoPilot"
This pull request introduces a new class `CSAnalogEncoder` in the `core/src/main/java/com/chopshop166/chopshoplib/sensors` directory. The class is a wrapper for the `AnalogEncoder` and implements the `IAbsolutePosition` interface.

Key changes include:

* Added a new class `CSAnalogEncoder` that extends `AnalogEncoder` and implements `IAbsolutePosition`. This class provides additional functionality to handle absolute position with an offset.

The new class includes:
  * Constructors to initialize the encoder with a specified channel, distance per rotation, and optional offset.
  * An overridden method `getAbsolutePosition` to return the absolute position considering the offset.
  * A method `setOffset` to set the offset value."